### PR TITLE
add tests, fix bugs, polish docs

### DIFF
--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -66,7 +66,6 @@ To obtain the exact p-value given the value of ``T_{obs}`` for ``N \lesssim 100`
 julia> squares_pvalue(T_obs, N)
 ```
 or
-<!-- the p value is defined as 1 - cdf. I don't know how you define the cdf in your code but it should follow that convention! -->
 ```Julia
 julia> squares_cdf(T_obs, N)
 ```
@@ -164,9 +163,9 @@ F(T_{obs} | nN) = \frac{F(T_{obs} | N)^n}{(1 + \Delta(T_{obs}))^{n-1}} \quad \te
 \end{align}
 ```
 
-``F(T_{obs} | L) \equiv P(T < T_{obs} | N)`` denotes the value of the cumulative of ``T`` for a sequence of ``L`` observations.
+``F(T_{obs} | L) \equiv P(T < T_{obs} | L)`` denotes the value of the cumulative of ``T`` for a (long) sequence of ``L`` observations. 
 
-So, if a total number of ``L`` data points have been observed, choose ``n`` and ``N`` so that ``n \cdot N = L``. The exact value of ``P(T < T_{obs} | N)`` is then calculated and further processed in accordance with the above equation.
+So, if a total number of ``L`` data points have been observed, choose ``n`` and ``N`` so that ``n \cdot N = L``. The exact value of ``F(T_{obs} | N) \equiv P(T < T_{obs} | N)`` is then calculated and further processed in accordance with the above equation.
 
 The approximate p-value for the data set then is:
 
@@ -177,8 +176,6 @@ p = 1 - F(T_{obs} | nN)
 ```
 
 ``\Delta(T_{obs})`` is a correction term (see equation (13) in [^2]) whose computation involves a 1D numerical integration. This is performed with the `quadgk()` function from the [`QuadGK.jl`](https://juliapackages.com/p/quadgk) package.
-
-
 ### Accuracy
 ---
 
@@ -208,6 +205,8 @@ julia> squares_cdf_approx(T_obs, L, epsp)
 
 This call yields a conservative approximation by setting the absolute error tolerance of the 1D integration that yields ``\Delta(T)`` to be one order of magnitude greater than necessary for the desired accuracy `epsp` of ``p`` or the cumulative. If not specified, the default value of the `quadgk()` function used for the integration is used. See [documentation](https://juliamath.github.io/QuadGK.jl/stable/).
 
+---
+
 **Rule of thumb**: to obtain a quick approximation of ``p`` or ``F(T | nN)``, call:
 
 ```Julia
@@ -217,7 +216,7 @@ or
 ```Julia
 julia> squares_cdf_approx(T_obs, L)
 ```
-And if a certain accuracy `epsp` ``\leq 10^{-14}`` is desired, call:
+And if a certain accuracy `epsp` ``\geq n \cdot 10^{-14}`` is desired, call:
 
 ```Julia
 julia> squares_pvalue_approx(T_obs, L, epsp)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,7 +13,6 @@ This code is based on the [original implementation](https://github.com/fredRos/r
 ## Package Features
 ---
 
-<!-- Do you have measurements to support your claim that the performance is better in the julia implementation? -->
 - Calculate the [*p-value*](https://en.wikipedia.org/wiki/P-value) for the *Squares test statistic*[^1] ``T`` observed in ``N`` independent trials of gaussian uncertainty
 - Improved performance and readability over the [original implementation](https://github.com/fredRos/runs) thanks to Julia
 - Inbuilt implementation for generating [*integer partitions*](https://en.wikipedia.org/wiki/Partition_(number_theory)) of an integer ``n`` into ``k`` parts

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -34,7 +34,6 @@ The hypothesis ``\mathcal{H}`` for the data is:
 - Each observation is normally distributed, ``X_i \sim \mathcal{N}(\mu_i, \sigma^2_i)``
 - Mean ``\mu_i`` and variance ``\sigma^2_i`` are known.
 
-<!-- I would use ** to emphasize runs instead `` but it's up to taste -->
 ``T`` is based on `runs` of weighted deviations from a mean value, observed in samples ``X_i`` from independent normal distributions.
 
 A `run` in this context refers to a sequence of observations that share a common attribute commonly called a `success`. Here an observation is called a *success*, ``S``, if the observed value exceeds the expected value. Similarly, an expected value exceeding the observation is considered a *failure*, ``F``.
@@ -46,9 +45,8 @@ A `run` in this context refers to a sequence of observations that share a common
     failure runs. Denote by ``A_j = \{X_{j_1} ,X_{j_2}, ...\}`` the set of
     observations in the ``j``-th success run.
 
--  Associate a weight ``\omega(A_j)`` with each success run:
+-  Associate a weight ``\omega(A_j)`` with each success run, where the sum over i is understood to cover all ``X_i \in A_j``:
 
-<!-- index i in the sum is not defined well.  Copy the explanation following (4) in https://arxiv.org/pdf/1005.3233.pdf as the rest of the text here is mostly copied, too -->
 ```math
 \begin{align}
 \omega(A_j) \equiv \chi_{run,j}^2 = \displaystyle\sum_i\frac{(X_i-\mu_i)^2}{\sigma_i^2}
@@ -89,13 +87,12 @@ p \equiv P (T ≥ T_{obs} ~|~ \mathcal{H})
 ```
 If ``\mathcal{H}`` is correct and all parameters are fixed, then ``p`` is a random variable with uniform distribution on ``[0, 1]``. An incorrect model will typically yield smaller values of ``p``.
 
-<!-- Refer to 10.1103/PhysRevD.83.012004 for the interpretation of p values -->
+See Frederik Beaujean, Allen Caldwell, Daniel Kollar, Kevin Kroeninger. *p-Values for Model Evaluation*. [arxiv[(https://arxiv.org/abs/1011.1674) for more information on interpreting p values.
 
 ### Approximation for large numbers of observations
 ---
 
 The cost for calculating the exact `p-value` for the Squares statistic as described in the initial paper[^1], scales with the number ``N`` of observations  like ``\exp[N^{\frac{1}{2}}]/N`` and quickly grows too large for ``N \gtrsim 80``.
-<!-- The rule of thumb N > 80 was true for my slow first implementation in mathematica -->
 
 The authors derived an approximation for large numbers of data in the follow-up paper[^2].
 

--- a/src/squares.jl
+++ b/src/squares.jl
@@ -11,7 +11,7 @@ function cachechi2(T_obs::Real, N::Int)
     res = zeros(N + 1)
     res[1] = NaN
 
-    for i = firstindex(res)+1:lastindex(res)
+    for i = firstindex(res) + 1 :lastindex(res)
         
         res[i] = logcdf(Chisq(i - 1), T_obs)
     end
@@ -58,18 +58,12 @@ function squares_cdf(T_obs::Real, N::Integer)
 
     end
 
-
     log_cumulative = cachechi2(T_obs, N)
 
     logpow2N1 = (N <= 63) ? log((1 << N) - 1) : N * log(2)
 
     p = zero(T)
 
-    # p = Threads.Atomic{float(T)}(0)
-    # Ps = zeros(Real, numthreads)
-
-    #TODO: think about creating a Partition() object for each thread and then initiate it within the thread
-    #Threads.@threads 
     for r = 1:N
 
         Mmax = min(r, N - r + 1)
@@ -101,11 +95,9 @@ function squares_cdf(T_obs::Real, N::Integer)
                 done = next_partition!(g)
             end
 
-            #Ps[threadid()] += exp(scale + log(ppi))
             p += exp(scale + log(ppi))
         end
     end
-    #p = sum(Ps)
 
     @assert p < 1
     return p

--- a/src/squares.jl
+++ b/src/squares.jl
@@ -60,7 +60,7 @@ function squares_cdf(T_obs::Real, N::Integer)
 
     log_cumulative = cachechi2(T_obs, N)
 
-    logpow2N1 = (N <= 63) ? log((1 << N) - 1) : N * log(2)
+    logpow2N1 = (N <= (8 * sizeof(Int) - 1)) ? log((1 << N) - 1) : N * log(2)
 
     p = zero(T)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,5 +22,3 @@ import Documenter
     Documenter.doctest(RunStatistics)
 
 end # testset
-
-

--- a/test/test_squares.jl
+++ b/test/test_squares.jl
@@ -3,12 +3,36 @@
 using RunStatistics
 using Test
 
-# Before you make a release, you should copy over all the tests I implemented in https://github.com/fredRos/runs/tree/master/test and make sure the numbers agree. There may some discrepancy because a different numerical integration is used but otherwise you should get the same numbers
-
 @testset "squares" begin
     T_obs = 3.4
     N = 30
 
     @test squares_pvalue(T_obs, N) ≈ 0.818208032939994
     @test squares_cdf(T_obs, N) ≈ 0.18179196706000597
+end
+
+@testset "squares_paper" begin
+    alpha = 0.001
+
+    @test abs(squares_pvalue(15.5, 5) - alpha) <= 0.00002
+    @test abs(squares_pvalue(23.8, 50) - alpha) <= 0.00002
+    @test abs(squares_pvalue(25.6, 100) - alpha) <= 0.00008
+end
+
+@testset "squares_mathematica" begin
+    n = 20
+    T = [2, 5, 10, 20, 50]
+    P = [0.8936721808595665, 0.42457437866154357, 0.06934906413527009, 0.0014159488909252227, 9.575188641974819e-9]
+    eps = [1e-15, 1e-15, 1e-15, 1e-15, 1e-15]
+
+    for i in 1:5
+        @test abs(squares_pvalue(T[i], n) - P[i]) <= eps[i]
+    end
+end
+
+@testset "squares_critical" begin
+    N = 50 
+
+    @test abs(squares_pvalue(19.645, 2 * N) - 0.01) <= 3e-5
+    @test abs(squares_pvalue(15.34, 2 * N) - 0.05) <= 1e-4
 end

--- a/test/test_squares_approx.jl
+++ b/test/test_squares_approx.jl
@@ -2,16 +2,91 @@
 
 using RunStatistics
 using Test
+using Distributions
+
+# I measured the timing for N=96 with the exact and approximate solution. See if julia is really faster. It seems some experiment with threading was done but without threads, I'd be surprised if it's faster than the C++ code built in release mode
 
 @testset "squares_approx" begin
 
     T_obs = 20
-    N = 30
-    n = 100
-    epsp = 10^(-2)
+    L = 800
+    N = 80
+    n = 10
+    Ns = [N, n]
+    epsp_1 = 10^(-2)
+    epsp_2 = 0
+        
 
-    @test squares_pvalue_approx(T_obs, N, n, epsp) ≈ 0.24164150728705625
-    @test squares_cdf_approx(T_obs, N, n, epsp) ≈ 0.7583584927129438
+    @test RunStatistics.squares_pvalue_approx(T_obs, Ns, epsp_1) ≈ 0.07082230261169509
+    @test RunStatistics.squares_cdf_approx(T_obs, Ns, epsp_1) ≈ 0.9291776973883049
+
+    @test RunStatistics.squares_cdf_approx(T_obs, L, epsp_1) ≈ 0.9291776973883049
+    @test RunStatistics.squares_pvalue_approx(T_obs, L, epsp_1) ≈ 0.07082230261169509
+
+
+    @test RunStatistics.squares_pvalue_approx(T_obs, Ns, epsp_2) == 0.0708223271587789
+    @test RunStatistics.squares_cdf_approx(T_obs, Ns, epsp_2) == 0.9291776728412211
+
+    @test RunStatistics.squares_cdf_approx(T_obs, L, epsp_2) == 0.9291776728412211
+    @test RunStatistics.squares_pvalue_approx(T_obs, L, epsp_2) == 0.0708223271587789
 end
 
-# I measured the timing for N=96 with the exact and approximate solution. See if julia is really faster. It seems some experiment with threading was done but without threads, I'd be surprised if it's faster than the C++ code built in release mode
+@testset "squares_approx_split" begin
+
+    Tobs = 15.5
+    N = 12
+    n = 2
+
+    F = squares_cdf(Tobs, N)
+    approx = F*F / (1.0 + RunStatistics.Delta(Tobs, N, N))
+
+    @test abs(approx - squares_cdf_approx(Tobs, [N, n])) <= 1e-15
+end 
+
+function test_on_grid(K::Integer, N::Integer, n::Real, eps::Real)
+
+    for i in 1:K
+        Tobs = 20 + 2 * i
+        @test abs(squares_cdf_approx(Tobs, [N, n]) - squares_cdf(Tobs, n * N)) <= eps
+    end 
+end
+
+@testset "squares_approx_grid" begin
+
+    test_on_grid(15, 40, 2, 2e-7)
+    # test_on_grid(15, 40, 3, 4e-7) expensive
+end 
+
+@testset "squares_approx_hH" begin
+    
+    Tobs = 15.5 
+    x = 3.3
+    N = 12 
+
+    @test abs(RunStatistics.h(Tobs, N) - 0.000373964) <= 1e-8
+    @test abs(RunStatistics.H(Tobs-x, Tobs, N) -  0.00245352) <= 1e-8
+    @test abs(RunStatistics.Delta(Tobs, N, N) - 0.00175994) <= 1e-8
+end
+
+@testset "squares_approx_cdf" begin
+    
+    @test abs(cdf(Chisq(12), 15.5) - 0.784775) <= 1e-6
+end
+
+@testset "squares_approx_interpolate" begin
+    Tobs = 32
+
+    F71 = squares_cdf_approx(Tobs, [71, 5])
+    F88 = squares_cdf_approx(Tobs, [88, 4])
+    F89 = squares_cdf_approx(Tobs, [89, 4])
+    F100 = squares_cdf_approx(Tobs, [Int64(100), 3.55])
+
+    @test abs(F71 - F100) <= 3e-9
+    @test abs(F71 - (F88 + 3*F89)/4) <= 2e-9
+end
+
+@testset "squares_approx_bound_error" begin
+
+    Tobs = 8
+    @test abs(squares_cdf(Tobs, 100) - (squares_cdf(Tobs, 50) ^ 2 - squares_cdf(Tobs, 100) * RunStatistics.Delta(Tobs, 100, 100))) <= 1e-3
+end

--- a/test/test_tobs.jl
+++ b/test/test_tobs.jl
@@ -4,5 +4,10 @@ using RunStatistics
 using Test
 
 @testset "t_obs" begin
-    @test RunStatistics.t_obs([-1, 1, 3, -2], 0, 1) == (10.0, Integer[2,3])
+
+    @test RunStatistics.t_obs([-1, 1, 3, -2], 0, 1) == (10.0, [2,3])
+    @test RunStatistics.t_obs([-1, 1, 3, -2], zeros(4), ones(4)) == (10.0, [2,3])
+
+    @test RunStatistics.t_obs([-1, 1, 3, -2, 1, 3], 0, 1) == (10.0, [[2,3],[5, 6]])
+    @test RunStatistics.t_obs([-1, 1, 3, -2, 1, 3], zeros(6), ones(6)) == (10.0, [[2,3],[5, 6]])
 end


### PR DESCRIPTION
Expanded test coverage
Fixed bugs in t_obs and squares_approx found during testing
Added tests from Fred's original implementation
Implemented changes to docs that Fred suggested

There is an issue with the ubuntu version during testing in line 63 of squares.jl:

 logpow2N1 = (N <= 63) ? log((1 << N) - 1) : N * log(2)

throws a Bound error for log(-1) for some reason, suggesting that it doesn't recognize the bitshift in the brackets. I was unable to find a fix/reason for the error.